### PR TITLE
removed deprecated parameter

### DIFF
--- a/backend-login-system/server.js
+++ b/backend-login-system/server.js
@@ -12,7 +12,7 @@ const mongoURI =
     ? process.env.MONGODB_URI_PROD
     : process.env.MONGODB_URI_DEV;
 
-mongoose.connect(mongoURI, { useNewUrlParser: true });
+mongoose.connect(mongoURI);
 const db = mongoose.connection;
 db.on('error', (error) => console.error(error));
 db.once('open', () => console.log('Connected to Database'));


### PR DESCRIPTION
warning:
[MONGODB DRIVER] Warning: useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version